### PR TITLE
Remove HuggingFace models from requirements.txt and improve Docker setup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,55 @@
+# Development Setup
+
+## Using Docker (Recommended)
+
+The project includes HuggingFace models that are installed in Docker containers rather than pip requirements.
+
+### Option 1: Run Jupyter with Docker script
+
+```bash
+./run_jupyter.sh
+```
+
+### Option 2: Use Docker Compose
+
+```bash
+# Start Jupyter notebook
+docker-compose up jupyter
+
+# Or start a development container
+docker-compose up -d dev
+docker-compose exec dev bash
+```
+
+### Option 3: Manual Docker commands
+
+```bash
+# Build images
+cd envs/docker/base_image
+docker build -t kzkedzierska/sc_foundation_evals:latest .
+cd ../jupyter  
+docker build -t sc_foundation_jupyter:latest .
+
+# Run Jupyter
+docker run -it --rm --gpus all -p 8888:8888 -v $(pwd):/workspace sc_foundation_jupyter:latest
+```
+
+## Local Installation (Not Recommended for HF Models)
+
+If you need to install locally, you'll need to manually install the HuggingFace models:
+
+```bash
+# Install base requirements
+pip install -r requirements.txt
+
+# Install HF models (not included in requirements.txt per best practices)
+pip install git+https://github.com/bowang-lab/scGPT.git@v0.1.6
+pip install git+https://huggingface.co/ctheodoris/Geneformer.git@5d0082c1e188ab88997efa87891414fdc6e4f6ff
+```
+
+## Why Docker?
+
+1. **HF Model Management**: HuggingFace models shouldn't be in requirements.txt per best practices
+2. **Reproducibility**: Exact environment with proper CUDA/PyTorch versions
+3. **Isolation**: No conflicts with your local Python environment
+4. **GPU Support**: Properly configured CUDA environment

--- a/INSTALLATION_GUIDE.md
+++ b/INSTALLATION_GUIDE.md
@@ -34,6 +34,49 @@ docker build -t sc_foundation_jupyter:latest .
 docker run -it --rm --gpus all -p 8888:8888 -v $(pwd):/workspace sc_foundation_jupyter:latest
 ```
 
+### Mounting Additional Data Directories
+
+By default, only the project directory is mounted at `/workspace`. To access datasets or files outside the project:
+
+#### Option 1: Modify run_jupyter.sh
+
+```bash
+# Edit run_jupyter.sh to add additional volume mounts
+docker run -it --rm \
+    --gpus all \
+    -p 8888:8888 \
+    -v "$(pwd)":/workspace \
+    -v ~/.huggingface:/root/.huggingface \
+    -v /path/to/your/datasets:/data \
+    -v /path/to/additional/files:/mnt/files \
+    sc_foundation_jupyter:latest
+```
+
+#### Option 2: Add to `docker-compose.yml`
+
+```yaml
+volumes:
+  - .:/workspace
+  - ~/.huggingface:/root/.huggingface
+  - /path/to/your/datasets:/data
+  - /path/to/additional/files:/mnt/files
+```
+
+#### Option 3: One-time manual run
+
+```bash
+docker run -it --rm --gpus all -p 8888:8888 \
+  -v $(pwd):/workspace \
+  -v /absolute/path/to/data:/data \
+  sc_foundation_jupyter:latest
+```
+
+**Access mounted data in notebooks:**
+
+- Project files: `/workspace/`
+- Additional data: `/data/` (or whatever you mounted it as)
+- Files are read/write accessible from within the container
+
 ## Local Installation (Not Recommended for HF Models)
 
 If you need to install locally, you'll need to manually install the HuggingFace models:

--- a/INSTALLATION_GUIDE.md
+++ b/INSTALLATION_GUIDE.md
@@ -92,7 +92,6 @@ pip install git+https://huggingface.co/ctheodoris/Geneformer.git@5d0082c1e188ab8
 
 ## Why Docker?
 
-1. **HF Model Management**: HuggingFace models shouldn't be in requirements.txt per best practices
-2. **Reproducibility**: Exact environment with proper CUDA/PyTorch versions
-3. **Isolation**: No conflicts with your local Python environment
-4. **GPU Support**: Properly configured CUDA environment
+1. **Reproducibility**: Exact environment with proper CUDA/PyTorch versions
+2. **Isolation**: No conflicts with your local Python environment
+3. **GPU Support**: Properly configured CUDA environment

--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ In this project, we assess two proposed foundation models in the context of sing
 
 ## Dependencies
 
-Currently the code requires the GPUs supported by flash attention, required for scGPT to run.
+This code has been developed and tested on Linux systems with NVIDIA GPUs.
 
-GPUs supported by flash attention are:
+**Compatible GPUs:**
 
-- Ampere, Ada, or Hopper GPUs (e.g., A100, RTX 3090, RTX 4090, H100).
-- Turing GPUs (T4, RTX 2080)
+- **Ampere, Ada, or Hopper**: A100, RTX 3090, RTX 4090, H100
+- **Turing**: T4, RTX 2080
+
+The code requires flash-attention for scGPT, which has strict GPU requirements.
 
 <details>
 <summary>Packages version</summary>
@@ -37,6 +39,7 @@ This code has been tested with the following versions of the packages:
 
 **Prerequisites:**
 
+- **CUDA-compatible NVIDIA GPU** (see Dependencies section above)
 - Docker with GPU support ([Installation Guide](https://docs.docker.com/get-docker/))
 - NVIDIA Container Toolkit for GPU access ([Setup Guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html))
 
@@ -55,7 +58,7 @@ docker-compose up jupyter
 ./run_jupyter.sh
 ```
 
-**Note:** This automatically pulls the pre-built Docker image `kzkedzierska/sc_foundation_evals:latest_jupyter` from Docker Hub.
+**Note:** This automatically pulls the pre-built Docker image `kzkedzierska/sc_foundation_evals:latest_notebook` from Docker Hub.
 
 Open <http://localhost:8888> to access Jupyter notebooks.
 

--- a/README.md
+++ b/README.md
@@ -33,99 +33,28 @@ This code has been tested with the following versions of the packages:
 
 </details>
 
-## Installation
+## Quick Start (Docker - Recommended)
 
-Below you can find the instructions on how to install the dependencies for this project. We provide two options: using conda/mamba or using Docker.
-
-<details>
-<summary>Conda / Mamba</summary>
-
-### Conda / Mamba
-
-You can install the dependencies using conda. To do so, you need to have conda installed on your machine. If you don't have it, you can install it from [here](https://docs.conda.io/en/latest/miniconda.html).
-
-We recommend using [mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html), since it is faster in our experience. You can install mamba following the guide [here](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html#operating-system-package-managers).
-
-To simplify installation, we provide the installation script that creates a new conda environment with all the dependencies installed. You can run the following command to create the environment:
+**Prerequisites:** Docker with GPU support
 
 ```bash
-bash envs/installation.sh
-```
-
-If the installation is successful, you will see the following message:
-
-```console
-2024-08-22 19:49:26 SUCCESS: All packages installed successfully.
-```
-
-And you can activate the environment by running:
-
-```bash
-conda activate sc_foundation_evals
-```
-
-</details>
-
-<details>
-<summary>Docker</summary>
-
-### Docker
-
-The docker image is available on DockerHub [here](https://hub.docker.com/repository/docker/kzkedzierska/sc_foundation_evals/general). You can pull the image by running:
-
-```bash
-docker pull kzkedzierska/sc_foundation_evals
-```
-
-The image is based on the `cnstark/pytorch:1.13.0-py3.9.12-cuda11.7.1-ubuntu20.04` image, and has all the dependencies installed. The Dockerfile used to build the image can be found in the `envs/docker` directory.
-
-You can also skip pulling the image since `docker` will pull it if needed. To run the interactive session with the image, you can use the following command:
-
-```bash
-docker run --gpus all -it kzkedzierska/sc_foundation_evals
-```
-
-If you want to be able to run the notebooks, run the image with the following tag:
-
-```bash
- docker run --gpus all -it --rm -p 8888:8888 -v  ./:/workspace kzkedzierska/sc_foundation_evals:latest_notebook
-```
-
-And open the link provided in the terminal in your browser. It should look like this:
-
-```console
-[I 2024-08-23 22:15:13.015 ServerApp] Serving notebooks from local directory: /workspace
-[I 2024-08-23 22:15:13.015 ServerApp] Jupyter Server 2.14.2 is running at:
-[I 2024-08-23 22:15:13.015 ServerApp] http://localhost:8888/tree
-[I 2024-08-23 22:15:13.015 ServerApp] http://127.0.0.1:8888/tree
-```
-
-For running the command on the server, consult the documentation of the server provider on how to forward the ports properly.
-
-</details>
-
-## Running the code
-
-### Downloading the weights
-
-To run notebooks you also need to have the weights of the models downloaded. scGPT weights are avaialble [here](https://github.com/bowang-lab/scGPT#pretrained-scgpt-model-zoo) and Geneformer weights are available in its repository. As per the instructions in the Geneformer repository, make sure you have `git lfs` installed before downloading the weights via repository cloning.
-
-### Copying this repository
-
-To run the code, you need to clone this repository.
-
-```bash
+# Clone repository and get data
 git clone https://github.com/microsoft/zero-shot-scfoundation
-```
-
-And download and unpack the data, stored at figshare (see [here](https://doi.org/10.6084/m9.figshare.24747228) for more details).
-
-```bash
 cd zero-shot-scfoundation
-# download and unpack the data
 wget https://figshare.com/ndownloader/files/43480497 -O data.zip
 unzip data.zip && rm data.zip
+
+# Start Jupyter notebooks
+docker-compose up jupyter
+# Or use the convenience script
+./run_jupyter.sh
 ```
+
+Open <http://localhost:8888> to access Jupyter notebooks.
+
+**📋 For detailed installation options and troubleshooting, see [INSTALLATION_GUIDE.md](INSTALLATION_GUIDE.md)**
+
+## Running the code
 
 ### Notebooks
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ This code has been tested with the following versions of the packages:
 
 ## Quick Start (Docker - Recommended)
 
-**Prerequisites:** Docker with GPU support
+**Prerequisites:**
+
+- Docker with GPU support ([Installation Guide](https://docs.docker.com/get-docker/))
+- NVIDIA Container Toolkit for GPU access ([Setup Guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html))
+
+**Note:** If you're using Docker in a non-privileged environment (clusters, shared systems), make sure your user is in the `docker` group or Docker is configured for rootless operation. See [Docker post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) for details.
 
 ```bash
 # Clone repository and get data
@@ -49,6 +54,8 @@ docker-compose up jupyter
 # Or use the convenience script
 ./run_jupyter.sh
 ```
+
+**Note:** This automatically pulls the pre-built Docker image `kzkedzierska/sc_foundation_evals:latest_jupyter` from Docker Hub.
 
 Open <http://localhost:8888> to access Jupyter notebooks.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,11 @@ version: '3.8'
 
 services:
   jupyter:
-    build: 
-      context: .
-      dockerfile: envs/docker/jupyter/Dockerfile
+    image: kzkedzierska/sc_foundation_evals:latest_jupyter
+    # Fallback: uncomment build section if pre-built image is not available
+    # build: 
+    #   context: .
+    #   dockerfile: envs/docker/jupyter/Dockerfile
     ports:
       - "8888:8888"
     volumes:
@@ -24,9 +26,11 @@ services:
 
   # Optional: Development container without Jupyter
   dev:
-    build: 
-      context: .
-      dockerfile: envs/docker/base_image/Dockerfile
+    image: kzkedzierska/sc_foundation_evals:latest
+    # Fallback: uncomment build section if pre-built image is not available  
+    # build: 
+    #   context: .
+    #   dockerfile: envs/docker/base_image/Dockerfile
     volumes:
       - .:/workspace
       - ~/.huggingface:/root/.huggingface  # Optional: Mount HuggingFace cache to avoid re-downloading models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  jupyter:
+    build: 
+      context: .
+      dockerfile: envs/docker/jupyter/Dockerfile
+    ports:
+      - "8888:8888"
+    volumes:
+      - .:/workspace
+      - ~/.huggingface:/root/.huggingface  # Optional: Mount HuggingFace cache to avoid re-downloading models
+    environment:
+      - CUDA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    working_dir: /workspace
+    command: jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --allow-root --NotebookApp.token='' --NotebookApp.password=''
+
+  # Optional: Development container without Jupyter
+  dev:
+    build: 
+      context: .
+      dockerfile: envs/docker/base_image/Dockerfile
+    volumes:
+      - .:/workspace
+      - ~/.huggingface:/root/.huggingface  # Optional: Mount HuggingFace cache to avoid re-downloading models
+    working_dir: /workspace
+    tty: true
+    stdin_open: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   jupyter:
-    image: kzkedzierska/sc_foundation_evals:latest_jupyter
+    image: kzkedzierska/sc_foundation_evals:latest_notebook
     # Fallback: uncomment build section if pre-built image is not available
     # build: 
     #   context: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 anndata==0.9.2
 colorlog==6.7.0
-scgpt==0.1.6
-geneformer==0.0.1
 PyComplexHeatmap
 numpy
 pandas

--- a/run_jupyter.sh
+++ b/run_jupyter.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Build the Docker images if they don't exist
+echo "Building Docker images..."
+
+pushd envs/docker/base_image || exit
+docker build -t kzkedzierska/sc_foundation_evals:latest .
+popd || exit
+
+pushd envs/docker/jupyter || exit
+docker build -t sc_foundation_jupyter:latest .
+popd || exit
+
+# Run Jupyter in Docker with volume mounting
+echo "Starting Jupyter notebook in Docker..."
+docker run -it --rm \
+    --gpus all \
+    -p 8888:8888 \
+    -v "$(pwd)":/workspace \
+    -v ~/.huggingface:/root/.huggingface \
+    sc_foundation_jupyter:latest
+
+echo "Jupyter notebook is running at http://localhost:8888"
+echo "Your project files are mounted at /workspace"

--- a/run_jupyter.sh
+++ b/run_jupyter.sh
@@ -11,11 +11,49 @@ if ! docker info &> /dev/null; then
     exit 1
 fi
 
+# Check GPU compatibility
+echo "Checking GPU compatibility..."
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "ERROR: This project requires CUDA-compatible GPUs, which are not available on macOS."
+    echo ""
+    echo "Apple Silicon Macs use Metal, not CUDA. This project requires:"
+    echo "  • NVIDIA GPUs with CUDA support"
+    echo "  • Ampere, Ada, Hopper, or Turing architecture (A100, RTX 3090/4090, H100, T4, RTX 2080, etc.)"
+    echo ""
+    echo "Please run this on a system with compatible NVIDIA hardware."
+    exit 1
+fi
+
+if ! command -v nvidia-smi &> /dev/null; then
+    echo "WARNING: nvidia-smi not found. This may indicate:"
+    echo "   • No NVIDIA GPU present"
+    echo "   • NVIDIA drivers not installed"
+    echo "   • Running on incompatible hardware"
+    echo ""
+    echo "This project requires CUDA-compatible NVIDIA GPUs:"
+    echo "  • Ampere, Ada, Hopper: A100, RTX 3090/4090, H100"
+    echo "  • Turing: T4, RTX 2080"
+    echo ""
+    read -p "Continue anyway? [y/N]: " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborting. Please ensure you have compatible NVIDIA hardware."
+        exit 1
+    fi
+elif ! nvidia-smi &> /dev/null; then
+    echo "ERROR: NVIDIA GPU not accessible or drivers not working properly."
+    echo "Please check your NVIDIA driver installation."
+    exit 1
+else
+    echo "NVIDIA GPU detected"
+fi
+
 # Try to pull the Docker image first, build as fallback
 echo "Attempting to pull pre-built Docker image..."
-if docker pull kzkedzierska/sc_foundation_evals:latest_notebook &> /dev/null; then
+IMAGE_NAME="kzkedzierska/sc_foundation_evals:latest_notebook"
+
+if docker pull "$IMAGE_NAME" &> /dev/null; then
     echo "Using pre-built Docker image"
-    IMAGE_NAME="kzkedzierska/sc_foundation_evals:latest_notebook"
 else
     echo "Pre-built image not available, building locally..."
     
@@ -27,16 +65,15 @@ else
     fi
     popd || exit 1
     
-    # Build jupyter image
+    # Build jupyter image with same tag as remote for consistency
     pushd envs/docker/jupyter || exit 1
-    if ! docker build -t sc_foundation_jupyter:latest .; then
+    if ! docker build -t "$IMAGE_NAME" .; then
         echo "ERROR: Failed to build Jupyter Docker image"
         exit 1
     fi
     popd || exit 1
     
     echo "Local build completed successfully!"
-    IMAGE_NAME="sc_foundation_jupyter:latest"
 fi
 
 # Run Jupyter in Docker with volume mounting

--- a/run_jupyter.sh
+++ b/run_jupyter.sh
@@ -1,15 +1,43 @@
 #!/bin/bash
 
-# Build the Docker images if they don't exist
-echo "Building Docker images..."
+# Check if Docker is running
+if ! docker info &> /dev/null; then
+    echo "ERROR: Docker is not running!"
+    echo ""
+    echo "Please ensure Docker is started and accessible, then try again."
+    echo "For installation and setup instructions, see: https://docs.docker.com/get-docker/"
+    echo "For GPU support, also ensure NVIDIA Container Toolkit is installed: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html"
+    echo ""
+    exit 1
+fi
 
-pushd envs/docker/base_image || exit
-docker build -t kzkedzierska/sc_foundation_evals:latest .
-popd || exit
-
-pushd envs/docker/jupyter || exit
-docker build -t sc_foundation_jupyter:latest .
-popd || exit
+# Try to pull the Docker image first, build as fallback
+echo "Attempting to pull pre-built Docker image..."
+if docker pull kzkedzierska/sc_foundation_evals:latest_jupyter &> /dev/null; then
+    echo "Using pre-built Docker image"
+    IMAGE_NAME="kzkedzierska/sc_foundation_evals:latest_jupyter"
+else
+    echo "Pre-built image not available, building locally..."
+    
+    # Build base image
+    pushd envs/docker/base_image || exit 1
+    if ! docker build -t kzkedzierska/sc_foundation_evals:latest .; then
+        echo "ERROR: Failed to build base Docker image"
+        exit 1
+    fi
+    popd || exit 1
+    
+    # Build jupyter image
+    pushd envs/docker/jupyter || exit 1
+    if ! docker build -t sc_foundation_jupyter:latest .; then
+        echo "ERROR: Failed to build Jupyter Docker image"
+        exit 1
+    fi
+    popd || exit 1
+    
+    echo "Local build completed successfully!"
+    IMAGE_NAME="sc_foundation_jupyter:latest"
+fi
 
 # Run Jupyter in Docker with volume mounting
 echo "Starting Jupyter notebook in Docker..."
@@ -18,7 +46,4 @@ docker run -it --rm \
     -p 8888:8888 \
     -v "$(pwd)":/workspace \
     -v ~/.huggingface:/root/.huggingface \
-    sc_foundation_jupyter:latest
-
-echo "Jupyter notebook is running at http://localhost:8888"
-echo "Your project files are mounted at /workspace"
+    "$IMAGE_NAME"

--- a/run_jupyter.sh
+++ b/run_jupyter.sh
@@ -13,9 +13,9 @@ fi
 
 # Try to pull the Docker image first, build as fallback
 echo "Attempting to pull pre-built Docker image..."
-if docker pull kzkedzierska/sc_foundation_evals:latest_jupyter &> /dev/null; then
+if docker pull kzkedzierska/sc_foundation_evals:latest_notebook &> /dev/null; then
     echo "Using pre-built Docker image"
-    IMAGE_NAME="kzkedzierska/sc_foundation_evals:latest_jupyter"
+    IMAGE_NAME="kzkedzierska/sc_foundation_evals:latest_notebook"
 else
     echo "Pre-built image not available, building locally..."
     


### PR DESCRIPTION
**What I've done:**

- Moved `scgpt` and `geneformer` installation to Docker environment 
- Implemented Docker-first development environment
- Added pull-first-then-build-fallback for reliability across different environments
- Reorganized documentation: concise README + detailed [INSTALLATION_GUIDE.md](./INSTALLATION_GUIDE.md)


**Key improvements:**

- Faster setup: pull pre-built image vs 15+ minute build time
- Better reliability: automatic fallback to local build when needed
- Included error handling and user guidance
- Docker Compose support for easy container management

**Usage**:

```bash
./run_jupyter.sh  # or docker-compose up jupyter
```

**Backwards compatibility**: Local `conda` installation still documented (with a warning) in [INSTALLATION_GUIDE.md](./INSTALLATION_GUIDE.md) for users who need it.